### PR TITLE
Fix ome-help GH view

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: Your New Jekyll Site
 markdown: redcarpet
 pygments: true
-baseurl: 
-clsbaseurl: /cls
+baseurl: /ome-help
+clsbaseurl: /ome-help/cls


### PR DESCRIPTION
Allow deployment of any fork of the ome-help site using http://username.github.io/ome-help.

Should be reviewable under http://snoopycrimecop.github.io/ome-help via http://ci.openmicroscopy.org/view/Docs/job/OME-help-staging/1.
