### PR TITLE
Add Google Analytics to the default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,7 +101,7 @@ navigation:
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
             })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-49953125-3', 'openmicroscopy.org');
+            ga('create', 'UA-49953125-3', 'auto');
             ga('send', 'pageview');
         </script>
 


### PR DESCRIPTION
This PR is opened against `gh-pages` which would imply only the live deployment site will have this snipper. On the flip side, this means we risk comflicts if the same lines in `default.html` are modified by PR.

/cc @gusferguson  @qidane @hflynn 
