### PR TITLE
Correcting incorrect downloads folder url

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -6,7 +6,7 @@ description: Suggestions for training Access to Zip archives of all the current 
 ---
 <p>It is convenient to put together material for OMERO training sessions from some of the resources and PDFs available on the website.</p>
 
-<p>We suggest using an A5 &#39;Getting Started with OMERO&#39; brochure which can be customised with your institution's server details. Generic UK and USA versions are in the downloads folder <a href="http://downloads.openmicroscopy.org/help/pdfs/a5-brochure/" target="_blank">a5-brochure</a>, as Word&reg; Docs for editing, or as generic PDFs.</p>
+<p>We suggest using an A5 &#39;Getting Started with OMERO&#39; brochure which can be customised with your institution's server details. Generic UK and USA versions are in the downloads folder <a href="http://downloads.openmicroscopy.org/help/resources/a5-brochure/" target="_blank">a5-brochure</a>, as Word&reg; Docs for editing, or as generic PDFs.</p>
 
 <p>This generally helps the participants in the training session to get started and logged in with minimal confusion.</p>
 


### PR DESCRIPTION
Correcting link to resources download folder 

<a href="http://downloads.openmicroscopy.org/help/resources/a5-brochure/" target="_blank">a5-brochure</a>

Will work when tested from staging now as folder has been created on live downloads site.
