### PR TITLE
Remove Read-Write group from Sharing Data section

### DIFF
--- a/sharing-data.html
+++ b/sharing-data.html
@@ -120,7 +120,11 @@ description: OMERO allows controlled sharing of data using groups with varying l
 
 </ul>
 
-<p>There are four types of group in OMERO:</p>
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<p>There are <!-- commented out for 5.1- four --> three types of group in OMERO:</p>
 
 <p><span class="bold">Private</span></p>
 <ul class="bullet-list">
@@ -146,6 +150,7 @@ description: OMERO allows controlled sharing of data using groups with varying l
 <li>a group owner can do anything to any member’s data except move it out of the group</li>
 </ul>
 
+<!-- commented out for 5.1 
 <p><span class="bold">Read-Write</span></p>
 <ul class="bullet-list">
 <li>all other members can see, interact with, edit and delete your data</li>
@@ -153,6 +158,10 @@ description: OMERO allows controlled sharing of data using groups with varying l
 <li>they can all draw ROIs and add annotations, edit and delete your data</li>
 <li>they cannot change group.</li>
 </ul>
+-->
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
 
 <p>The main points can be summarised as:</p>
 <ul class="bullet-list">
@@ -160,8 +169,8 @@ description: OMERO allows controlled sharing of data using groups with varying l
 <li>your rendering settings cannot be over-written by any other user</li>
 <li>you can remove any annotations, comments or ROIs added by other group members</li>
 <li>no other members can move your data between groups</li>
-<li>only you, a group owner or an Administrator can delete your data except in a read-write group</li>
-<li>in a read-write group other group members can delete your data.</li>
+<li>only you, a group owner or an Administrator can delete your data<!-- commented out for 5.1  except in a read-write group</li>
+<li>in a read-write group other group members can delete your data-->.</li>
 </ul>
 
 <div class="line-block">
@@ -208,17 +217,16 @@ description: OMERO allows controlled sharing of data using groups with varying l
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
+<!-- commented out for 5.1 
 <span class="bold">Read-Write Group</span>
 
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
+Line block deleted from here
 
 <img alt="../images/sharingDataReadWrite.jpg" class="align-center" src="images/sharingDataReadWrite.jpg" style="width: 80%;" />
 
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
+Line block deleted from here
+
+-->
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->


### PR DESCRIPTION
Take out all references to read-write and permissions therein. 

Reduce groups existing to number 3 instead of 4.

Updated PDF on downloads-staging.