### PR TITLE
Fixing team contact link & info

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,7 +73,7 @@ navigation:
             link: resources.html
           - name: Previous Versions
             link: previous.html
-          - name: Contact the OMERO Team
+          - name: Contact OME
             link: contact.html
           - name: Main OME Website
             href: http://www.openmicroscopy.org/site" target="_blank

--- a/contact.html
+++ b/contact.html
@@ -2,7 +2,7 @@
 layout: default
 title: Contact the OMERO Team
 menu-id: l1-more
-description: Details on how to contact the OMERO team and OME community and development teams with any questions, issues or problems.
+description: Details on how to contact the OME community and development teams with any questions, issues or problems.
 ---
 <p>The OMERO User Help materials are created and updated by the OME User Experience Team.</p>
 

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Contact the OMERO Team
+title: Contact OME
 menu-id: l1-more
 description: Details on how to contact the OME community and development teams with any questions, issues or problems.
 ---


### PR DESCRIPTION
Reverting change from #60 - we don't want to imply the mailing lists are OMERO branded, let's stick with contact 'OME'