### PR TITLE
Correct missing image and typo

### DIFF
--- a/demo-server.html
+++ b/demo-server.html
@@ -75,7 +75,7 @@ description: Details on how to request a free account on our demo server to enab
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<img alt="../images/gettingStartedSpanner.jpg" class="align-center" src="images/gettingStartedSpanner.jpg" style="width: 75%;" />
+<img alt="../images/gettingStarted5Spanner.jpg" class="align-center" src="images/gettingStarted5Spanner.jpg" style="width: 80%;" />
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->

--- a/export.html
+++ b/export.html
@@ -159,7 +159,7 @@ description: How to export any image as an OME-TIFF file, save it as a JPEG, PNG
 
 <p>The OME-TIFF is attached to the image as a ZIP archive.</p>
 
-<p>Click <span class="bold">Download</span> in the Activity Window to download the archive.</p>
+<p>Click <span class="bold">Download</span> in the Activities window to download the archive.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->


### PR DESCRIPTION
First "spanner" image missing on demo page (deleted with GS 4.4) - GS 5.1 version used instead.
Incidentally noticed that "Activities window" is called "Activity window" in Export.

- Check first image on Demo page present.
- Check correct name used for Activities window

Export PDF updated on staging downloads