### PR TITLE
Adding link to OMERO as a Public Repository documentation

### DIFF
--- a/publish.html
+++ b/publish.html
@@ -656,7 +656,7 @@ The Cell Image Library</a></p></li>
 
 <p>OMERO.gallery provides a basic gallery front end based on the Group-Project-Dataset-Image, and is a good starting point to develop a bespoke front end.
 
-<p>An example of this is:
+<p>An example of this can be seen at:
 
 <ul>
 

--- a/publish.html
+++ b/publish.html
@@ -635,7 +635,7 @@ Click on thumbnail or
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<p>OMERO can be used as a public data repository with either a custom web app or using the OMERO.gallery app.</p>
+<p>In addition to adding the Public User to allow access to your data, the appearance of OMERO.web can be customised or you can use a separate custom app to tailor the front end of your OMERO installation to your target audience.</p>
 
 <p>There are a number of repositories based on OMERO with bespoke front ends, including:</p>
 

--- a/publish.html
+++ b/publish.html
@@ -668,7 +668,7 @@ The Cell Image Library</a></p></li>
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<p>Full documentation on how to set up OMERO as a public repository and details of customisation options can be found in the <a href="http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/public.html#public-user" target="_blank" class="external-url">OMERO Repository documentation</a>.</p>
+<p>Full documentation on how to set up OMERO as a public repository and details of customisation options can be found in the <a href="https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/index.html#optimizing-omero-as-a-data-repository" target="_blank" class="external-url">OMERO Repository documentation</a>.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->

--- a/publish.html
+++ b/publish.html
@@ -13,7 +13,7 @@ description: How to create figures and movies from data on OMERO, and publicaly 
 <a href="#figures">Creating figures</a><br />
 <a href="#movies">Creating movies</a><br />
 <a href="#public">Using a public group</a><br />
-
+<a href="#repository">Using OMERO as a Public Repository</a>
 </p>
 </div><!-- End Page Navigation -->
 
@@ -581,7 +581,7 @@ Click on thumbnail or
 </body>
 </textarea>
 
-<form>
+</form>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -622,6 +622,57 @@ Click on thumbnail or
 </li>
 
 </ol>
+
+<p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<h2><a class="anchor" id="repository"></a>Using OMERO as a Public Repository</h2>
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<p>OMERO can be used as a public data repository with either a custom web app or using the OMERO.gallery app.</p>
+
+<p>There are a number of repositories based on OMERO with bespoke front ends, including:</p>
+
+<ul>
+
+<li><p><a href="http://jcb-dataviewer.rupress.org" target="_blank" class="external-url">Journal of Cell Biology (JCB) Data Viewer</a></p></li>
+
+<li><p><a href="http://odr.stowers.org/websimr/" target="_blank" class="external-url">Stowers Institute Original Data Repository (ODR)</a></p></li>
+
+<li><p><a href="http://www.cellimagelibrary.org" target="_blank" class="external-url">
+The Cell Image Library</a></p></li>
+
+</ul>
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<p>OMERO.gallery provides a basic gallery front end based on the Group-Project-Dataset-Image, and is a good starting point to develop a bespoke front end.
+
+<p>An example of this is:
+
+<ul>
+
+<li><p><a href="http://cci02.liv.ac.uk/gallery/" target="_blank" class="external-url">Liverpool  Centre for Cell Imaging (CCI) OMERO Gallery</a></p></li>
+
+</ul>
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<p>Full documentation on how to set up OMERO as a public repository and details of customisation options can be found in the <a href="http://www.openmicroscopy.org/site/support/omero5.1/sysadmins/public.html#public-user" target="_blank" class="external-url">OMERO Repository documentation</a>.</p>
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
 
 <p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
 


### PR DESCRIPTION
In Publishing with OMERO - added some explanatory text, links to examples and link to documentation for Public Repository.

Check links and text.

Note: link to Public Repo documentation won't work until the docs has been made live on OME to web site.

Updated PDF on downloads staging.