### PR TITLE
Updating the version number of the zip archive for 5.1.3

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -16,7 +16,7 @@ description: Suggestions for training Access to Zip archives of all the current 
 
 <ul>
 
-<li>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_1_2.zip">Version 5.1.2</a> (Zipped PDFs 143 MB)</li>
+<li>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_1_3.zip">Version 5.1.3</a> (Zipped PDFs 143 MB)</li>
 <br/>
   
 <li>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_0_8.zip">Version 5.0.8</a> (Zipped PDFs 185 MB)</li>


### PR DESCRIPTION
Forgot to update zip archive version number. Simpler to do it in a separate branch.

Check version number in Zip archive download is 5.1.3

PDFs not updated yet, so link will be broken until downloads updated.