### PR TITLE
Travis validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 sudo: false
 cache: bundler
-rvm:
-- 2.2.2
+rvm: 2.2.2
 install: bundle install
-script: bundle exec jekyll build --config _config_dev.yml && bundle exec htmlproof ./_site --disable-external
+script:
+    - bundle exec jekyll build --config _config_dev.yml
+    - bundle exec htmlproof ./_site --disable-external
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 rvm:
 - 2.2.2
 install: bundle install
-script: bundle exec jekyll build --baseurl '' && bundle exec htmlproof ./_site --disable-external
+script: bundle exec jekyll build --config _config_dev.yml && bundle exec htmlproof ./_site --disable-external
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 rvm:
 - 2.2.2
 install: bundle install
-script: bundle exec jekyll build && bundle exec htmlproof . --disable-external
+script: bundle exec jekyll build && bundle exec htmlproof ./_site --disable-external
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm: 2.2.2
 install: bundle install
 script:
     - bundle exec jekyll build --config _config_dev.yml
-    - bundle exec htmlproof ./_site --disable-external
+    - bundle exec htmlproof ./_site --disable-external --empty-alt-ignore 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm: 2.2.2
 install: bundle install
 script:
     - bundle exec jekyll build --config _config_dev.yml
-    - bundle exec htmlproof ./_site --disable-external --alt-ignore *.gif
+    - bundle exec htmlproof ./_site --disable-external --alt-ignore "\/images\/.*.gif"
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm: 2.2.2
 install: bundle install
 script:
     - bundle exec jekyll build --config _config_dev.yml
-    - bundle exec htmlproof ./_site --disable-external --empty-alt-ignore 
+    - bundle exec htmlproof ./_site --disable-external --alt-ignore *.gif
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
-addons:
-  apt_packages:
-    - tidy
+language: python
 
-script:
-  - tidy -qe *.html
+python: 2.7
+
+install:
+ - pip install html5validator
+
+script: "html5validator"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# This (sudo: false) is needed to "run on container-based infrastructure" on
+# which cache: is available
+# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
+addons:
+  apt_packages:
+    - tidy
+
+script:
+  - tidy -qe *.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
-# This (sudo: false) is needed to "run on container-based infrastructure" on
-# which cache: is available
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+language: ruby
 sudo: false
-
-language: python
-
-python: 2.7
-
-install:
- - pip install html5validator
-
-script: "html5validator"
+cache: bundler
+rvm:
+- 2.2.2
+install: bundle install
+script: bundle exec jekyll build && bundle exec htmlproof . --disable-external
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 rvm:
 - 2.2.2
 install: bundle install
-script: bundle exec jekyll build && bundle exec htmlproof ./_site --disable-external
+script: bundle exec jekyll build --baseurl '' && bundle exec htmlproof ./_site --disable-external
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "rake"
+gem "jekyll"
+gem "html-proofer"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
-gem "rake"
+
 gem "jekyll"
 gem "html-proofer"

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,5 @@
+name: OMERO User Help Website
+markdown: redcarpet
+highlighter: pygments
+baseurl: ''
+clsbaseurl: /cls


### PR DESCRIPTION
See https://trello.com/c/SM7560up/279-check-html-of-help-pages

After trying multiple tools which were not coping with the Jekyll layout, I implemented the solution described in http://jekyllrb.com/docs/continuous-integration/. The Travis build should now build the Jekyll documentation and run HTML proofing on `./_site`.

The `_config_dev.yml` is added as a workaround of a bug where htmlproof does not work correctly with non empty `baseurl` (see https://github.com/gjtorikian/html-proofer/pull/178). Current Travis status should list 107 failures - mostly missing alt attributes for images in the documentation.

/cc @gusferguson @hflynn 