### PR TITLE
Add Current OMERO Version flag to appropriate pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ because this is the only way to maintain the desired order with Jekyll.
 **Page Files**
 
 Individual files for the pages contain the variables to be inserted in the
-appropriate field in default.html for: page title, menu ID, PDF name and
-description metadata and text. Pages can be written in HTML or Markdown.
+appropriate field in default.html for: page title, menu ID, PDF name,
+description metadata and text and whether to display the Current OMERO Version number. 
+Pages can be written in HTML or Markdown.
 They have a short header and then the page content in the form:
 
 /---
@@ -80,6 +81,8 @@ menu-id: l1-quickstart
 pdfs:
     - getting-started-5.pdf
 description: Metadata header for each page.
+version:
+    - yes
 /---
 <page content>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -113,7 +113,9 @@ navigation:
 
                     <div id="banner">
                         <p><img src="{{ site.baseurl }}/images/omero-logo-on-white-220.png" alt="OMERO logo" /></p>
+                        
                         <h1>User Help</h1>
+                        
                     </div> <!-- banner -->
 
                     <!-- Level 1 List -->
@@ -124,7 +126,7 @@ navigation:
                         {% endfor %}
 
                     </ul><!-- End Level 1 List -->
-
+                    
                     <div id="footer">
 
                         <p>&copy; 2000-2015<br/>The Open Microscopy Environment</p>
@@ -141,14 +143,23 @@ navigation:
                         <a href="http://downloads.openmicroscopy.org/help/pdfs/{{ pdf }}" target="_blank"> <img src="{{ site.baseurl }}/images/pdf_download.png" width="32" height="41" alt="Download PDF" class="header-right" /></a>
                         {% endfor %}
                         
-                         <h1>{{ page.title }}</h1>
-                         
+                        <h1>{{ page.title }}</h1>
+
+                        {% for yes in page.version %}
+                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.1.4</div>
+                        {% endfor %}
+                        
+
                     </div> <!-- End page-header -->
                     <div id="page-body">
 
                         <div id="page-contents">
                             
                             <a class="top" id="top">Top</a>
+                            
+                            <div class="line-block">
+                            <div class="line"><br /></div> <!-- end #line -->
+                            </div> <!-- end #line-block -->
                             
                             {{ content }}
 

--- a/client-memory.html
+++ b/client-memory.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - client-memory.pdf
 description: How to increase the memory allocated for the OMERO.insight client.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/cls-getting-started.html
+++ b/cls-getting-started.html
@@ -4,11 +4,11 @@ title: Getting Started with CLS OMERO
 pdfs:
     - cls-omero.pdf
 description: The University of Dundee CLS has an OMERO server enabling students and staff to store image data centrally. The OMERO.insight client enables uploading, viewing and downloading of data from any computer or laptop on or off-campus.
+version:
+    - yes
 ---
 <div class="page-navigation">
-
 <h2>Contents</h2>
-
 <p>
 <a href="#introduction">Introduction</a><br />
 <a href="#insight">Installing OMERO.insight</a><br />

--- a/css/display.css
+++ b/css/display.css
@@ -62,6 +62,7 @@ body {
 	border: 1.5px solid silver;
 	padding-top: 45px;
 	overflow: hidden;
+	bottom: 2px;
 }
 
 /*Page Header*/
@@ -83,6 +84,15 @@ body {
 	color: #00426c;
 	font-weight: bold;
 	letter-spacing: 0.1em;
+}
+
+#page-header .version-flag {
+	float: left;
+	color: #00416d;
+	font-size: 105%;
+	position: relative;
+	bottom: 10px;
+	left: 5px;
 }
 
 .previous {
@@ -257,7 +267,6 @@ img.header-right {
 #page-body .warning-title {
 }
 
-
 #page-body .page-navigation {
 	font-weight: bold;
 }
@@ -269,7 +278,6 @@ img.header-right {
 #page-body .indent2 {
 	padding-left: 40px;
 }
-
 
 #page-body .indent3 {
 	padding-left: 60px;

--- a/demo-server.html
+++ b/demo-server.html
@@ -3,9 +3,10 @@ layout: default
 title: OMERO Demo Server
 menu-id: l1-quickstart
 description: Details on how to request a free account on our demo server to enable you to explore the OMERO platform using examples of your own data.
+version:
+    - yes
 ---
 <div class="page-navigation">
-
 <h2>Contents</h2>
 <p>
 <a href="#introduction">Introduction</a><br />

--- a/dropbox.html
+++ b/dropbox.html
@@ -5,6 +5,8 @@ menu-id: l1-other
 pdfs:
     - dropbox.pdf
 description: How to use OMERO.dropbox to enable automated import of files that are placed in a monitored folder.
+version:
+    - yes
 ---
 <p>OMERO.dropbox is designed to enable automated import of files that are placed in a monitored folder.</p>
 

--- a/export.html
+++ b/export.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - export.pdf
 description: How to export any image as an OME-TIFF file, save it as a JPEG, PNG or TIFF or if it was archived at import, download it in the original image format.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/flimfit.html
+++ b/flimfit.html
@@ -6,7 +6,6 @@ pdfs:
     - flimfit.pdf
 description: FLIMfit is a software tool from, Imperial College London, that is designed to facilitate analysis and visualisation of time-resolved data from FLIM (Fluorescence Lifetime Imaging). FLIMfitt can connect to OMERO to load data directly from the OMERO server, or work with local files.
 ---
-
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->

--- a/getting-started-5.html
+++ b/getting-started-5.html
@@ -5,6 +5,8 @@ menu-id: l1-quickstart
 pdfs:
     - getting-started-5.pdf
 description: Using OMERO.insight Version 5 to upload, view and download data from any personal computer.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/imagej.html
+++ b/imagej.html
@@ -5,6 +5,8 @@ menu-id: l1-quickstart
 pdfs:
     - imagej.pdf
 description: How to use OMERO.insight with ImageJ and Fiji to access data on an OMERO server.
+version:
+    - yes
 ---
 <div class="page-navigation">
 

--- a/importing-data-5.html
+++ b/importing-data-5.html
@@ -5,13 +5,9 @@ menu-id: l1-workflow
 pdfs:
     - importing-data-5.pdf
 description: Using OMERO.insight Version 5 to import image data onto the OMERO server.
+version:
+    - yes
 ---
-<p>Using  OMERO.insight to import image data onto the OMERO server.</p>
-
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
 <div class="page-navigation">
 <h2>Contents</h2>
 <p>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 layout: default
 title: OMERO User Help - Home Page
 description: The Home page for the User Help documentation for OMERO.insight, OMERO.web, OMERO.figure, using ImageJ with OOMERO and much more.
+version:
+    - yes
 ---
 <p>These pages contain the User Help for applications which can connect to an OMERO server or use OMERO plugins.</p>
 

--- a/managing-data.html
+++ b/managing-data.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - managing-data.pdf
 description: Using OMERO.insight to manage image data.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/measurement-tool.html
+++ b/measurement-tool.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - measurement-tool.pdf
 description: Using the measurement tool in OMERO.insight to draw Regions of Interest (ROIs) and undertake analysis.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/previous.html
+++ b/previous.html
@@ -3,6 +3,8 @@ layout: default
 title: Guides for Previous Versions
 menu-id: l1-more
 description: Accesss to Zip archives of all the previous versions of the User Help documentation.
+version:
+    - yes
 ---
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->

--- a/publish.html
+++ b/publish.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - publish.pdf
 description: How to create figures and movies from data on OMERO, and publicaly share images.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/resources.html
+++ b/resources.html
@@ -3,6 +3,8 @@ layout: default
 title: Training Course Material
 menu-id: l2-more
 description: Suggestions for training Access to Zip archives of all the current User Guide PDFs and various customised or one-off guides.
+version:
+    - yes
 ---
 <p>It is convenient to put together material for OMERO training sessions from some of the resources and PDFs available on the website.</p>
 

--- a/search.html
+++ b/search.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - search.pdf
 description: How to use the search functionality in OMERO.insight and OMERO.web.
+version:
+    - yes
 ---
 <div class="page-navigation">
 

--- a/sharing-data.html
+++ b/sharing-data.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - sharing-data.pdf
 description: OMERO allows controlled sharing of data using groups with varying levels of access and interaction.
+version:
+    - yes
 ---
 <div class="page-navigation">
 

--- a/troubleshooting.html
+++ b/troubleshooting.html
@@ -5,6 +5,8 @@ menu-id: l2-more
 pdfs:
     - troubleshooting.pdf
 description: Help with any problems encountered with OMERO.
+version:
+    - yes
 ---
 <div class="page-navigation">
 <h2>Contents</h2>

--- a/urls-to-data.html
+++ b/urls-to-data.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - urls-data.pdf
 description: URLs allow direct access to Projects, Datasets and images from the OMERO.web client, electronic log books, wikis or web pages.
+version:
+    - yes
 ---
 <p>Since the 4.4.4 release of OMERO, the OMERO.web client has supported direct
 linking to Projects, Datasets, Images etc. using a URL of this form:</p>

--- a/utility-scripts.html
+++ b/utility-scripts.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - utility-scripts.pdf
 description: Scripts allow users to add server-side functionality to the OMERO clients.
+version:
+    - yes
 ---
 <p>As well as scripts for exporting images and figures, OMERO.insight also
 includes &#8216;Util Scripts&#8217; to add other functionality.</p>

--- a/viewing-data.html
+++ b/viewing-data.html
@@ -5,6 +5,8 @@ menu-id: l1-workflow
 pdfs:
     - viewing-data.pdf
 description: Viewing and working with image data using OMERO.insight and OMERO.web.
+version:
+    - yes
 ---
 <div class="page-navigation">
 

--- a/web-client.html
+++ b/web-client.html
@@ -5,6 +5,8 @@ menu-id: l1-quickstart
 pdfs:
     - web-client.pdf
 description: The OMERO.web client allows images on an OMERO server to be viewed from any standard web browser.
+version:
+    - yes
 ---
 <p>Using OMERO.web to view and work with image data via a web browser.</p>
 


### PR DESCRIPTION
Uses a flag in the header of each page to determine if Current OMERO Version number is shown in header.

- Check that text is legible in rendered pages.
- Look at all pages to see if ones flagged are appropriate (should it be added to any others).
- check README - updated to reflect additional flag in header.

Screenshot shows where flag should be positioned. Tried out all sorts of combinations - this seemed to work best.

![safari](https://cloud.githubusercontent.com/assets/1552703/9848241/22868cca-5ad7-11e5-8a5a-319502128ab9.png)
