### PR TITLE
Add Webstart deprecation warning to relevant pages.

### DIFF
--- a/demo-server.html
+++ b/demo-server.html
@@ -128,7 +128,7 @@ description: Details on how to request a free account on our demo server to enab
 <div class="warning">
 <p class="warning-title">Warning!</p>
 
-<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
 
 <p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
 

--- a/demo-server.html
+++ b/demo-server.html
@@ -21,7 +21,7 @@ description: Details on how to request a free account on our demo server to enab
 <p>A free account on our demo server enables you to explore the OMERO platform using examples of your own data.</p>
 
 <p>To register for a free demo account, go to the 
-<a class="reference external" href="http://qa.openmicroscopy.org.uk/registry/demo_account/">registration page</a>.</p>
+<a class="reference external" href="http://qa.openmicroscopy.org.uk/registry/demo_account/" target="_blank">registration page</a>.</p>
 
 <p>We will email you with the server name and your username and password.</p>
 
@@ -65,7 +65,7 @@ description: Details on how to request a free account on our demo server to enab
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<p>Download the <span class="bold">OMERO.insight</span> client for your platform by clicking on the appropriate link on the <a class="reference external" href="http://downloads.openmicroscopy.org/latest/omero5/">downloads page</a>.</p>
+<p>Download the <span class="bold">OMERO.insight</span> client for your platform by clicking on the appropriate link on the <a class="reference external" href="http://downloads.openmicroscopy.org/latest/omero5/" target="_blank">downloads page</a>.</p>
 
 <p>After download, unzip and install the OMERO.insight client as you would for any other application.</p>
 <p>Launch OMERO.insight, and you will see the login screen.</p>
@@ -125,17 +125,26 @@ description: Details on how to request a free account on our demo server to enab
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<p>To use the OMERO.insight Java Web Start client click on the following link:</p>
+<div class="warning">
+<p class="warning-title">Warning!</p>
 
-<p><a class="reference external" href="http://demo.openmicroscopy.org/webstart/">OMERO.insight Java Web Start</a></p>
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
 
-<p>Follow the instructions to download and run it.</p>
+<p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
 
-<p>Log in as described above.</p>
+</div><!-- End warning -->
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
+
+<p>To use the OMERO.insight Java Web Start client click on the following link:</p>
+
+<p><a class="reference external" href="http://demo.openmicroscopy.org/webstart/" target="_blank">OMERO.insight Java Web Start</a></p>
+
+<p>Follow the instructions to download and run it.</p>
+
+<p>Log in as described above.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -151,28 +160,28 @@ description: Details on how to request a free account on our demo server to enab
 
 <p>To use the OMERO.web client click on the following link:</p>
 
-<p><a class="reference external" href="http://demo.openmicroscopy.org/webclient/login">OMERO.web</a></p>
+<p><a class="reference external" href="http://demo.openmicroscopy.org/webclient/login" target="_blank">OMERO.web</a></p>
 
 <p>The server name is entered automatically, and you enter your demo account username and password as described above.</p>
 
 <p>Please change your password as soon as you have logged in. The easiest way to do this is via:</p>
 
-<p><a class="reference external" href="http://demo.openmicroscopy.org/webadmin/myaccount/edit/">Web Admin</a></p>
+<p><a class="reference external" href="http://demo.openmicroscopy.org/webadmin/myaccount/edit/" target="_blank">Web Admin</a></p>
 
 <p>The workflow-based guides available on this website are applicable to the demo server, using screenshots
 to illustrate how to perform common tasks such as importing and viewing data, and using the measurement tool.</p>
 
 <p>An overview of some OMERO’s features is available in a short showcase video at:</p>
 
-<p><a class="reference external" href="http://cvs.openmicroscopy.org.uk/snapshots/movies/omero-4-4/mov/OMERO-Showcase.mov">Showcase Video</a></p>
+<p><a class="reference external" href="http://cvs.openmicroscopy.org.uk/snapshots/movies/omero-4-4/mov/OMERO-Showcase.mov" target="_blank">Showcase Video</a></p>
 
 <p>If you have any questions, suggestions, comments or proposals, please take advantage of the OME community&#8217;s expertise and join our forums or mailing lists:</p>
-<p><a class="reference external" href="http://www.openmicroscopy.org/community/">Forums</a></p>
-<p><a class="reference external" href="http://www.openmicroscopy.org/site/community/mailing-lists/">Mailing Lists</a></p>
+<p><a class="reference external" href="http://www.openmicroscopy.org/community/" target="_blank">Forums</a></p>
+<p><a class="reference external" href="http://www.openmicroscopy.org/site/community/mailing-lists/" target="_blank">Mailing Lists</a></p>
 
 <p class="first">For more information on OME and OMERO visit our main site::</p>
 
-<p><a class="reference external" href="http://www.openmicroscopy.org/site">Open Microscopy Environment</a></p>
+<p><a class="reference external" href="http://www.openmicroscopy.org/site" target="_blank">Open Microscopy Environment</a></p>
 
 <p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
 

--- a/getting-started-5.html
+++ b/getting-started-5.html
@@ -512,7 +512,7 @@ your standard login for the institution&#8217;s networked computers.</p>
 <div class="warning">
 <p class="warning-title">Warning!</p>
 
-<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
 
 <p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
 

--- a/getting-started-5.html
+++ b/getting-started-5.html
@@ -505,6 +505,23 @@ your standard login for the institution&#8217;s networked computers.</p>
 
 <h2><a class="anchor" id="web-start"></a>Using Web Start</h2>
 
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
+<div class="warning">
+<p class="warning-title">Warning!</p>
+
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
+
+<p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
+
+</div><!-- End warning -->
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
 <p>If users have restrictions on their ability to install software on their computers, a version of the OMERO.insight client can be downloaded as a Web Start package via the OMERO.web client.</p>
 
 <p>Using Web Start ensures you are always using an up-to-date version of OMERO.insight. For all practical purposes the Web Start OMERO.insight client is identical to the standard OMERO.insight client.</p>

--- a/web-client.html
+++ b/web-client.html
@@ -365,7 +365,7 @@ description: The OMERO.web client allows images on an OMERO server to be viewed 
 <div class="warning">
 <p class="warning-title">Warning!</p>
 
-<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
 
 <p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
 

--- a/web-client.html
+++ b/web-client.html
@@ -362,6 +362,19 @@ description: The OMERO.web client allows images on an OMERO server to be viewed 
 
 <p>Further details are in the <a href="http://help.openmicroscopy.org/getting-started-5.html#web-start" target="_blank">Getting Started with OMERO.insight 5</a> section.</p>
 
+<div class="warning">
+<p class="warning-title">Warning!</p>
+
+<p class="warning-text">Due to the steady increase of issues not under OMERO's control, continued support of Java Web Start for distribution of the OMERO.insight is not sustainable and is likely to become impossible in the near future.</p>
+
+<p class="warning-text">Therefore from OMERO version 5.1.4, Java Webstart for OMERO.insight will be deprecated, and then removed for version 5.2.</p>
+
+</div><!-- End warning -->
+
+<div class="line-block">
+<div class="line"><br /></div> <!-- end #line -->
+</div> <!-- end #line-block -->
+
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->


### PR DESCRIPTION
Also added "target=blank" tags to Demo page external links.

Check Getting Started Version 5, Web Client and Demo Server pages for warning on deprecation and removal of Webstart.

Proof and approve message (practically a cut and paste from the blog post).

PDFs updated on downloads staging.