### PR TITLE
Virtual Microcope - correcting menu-id flag to "other"

### DIFF
--- a/virtual-microscope.html
+++ b/virtual-microscope.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Virtual Microscope - Getting Started
-menu-id: l1-quickstart
+menu-id: l1-other
 pdfs:
     - virtual-microscope.pdf
 description: The Virtual Microscope is a University of Dundee OMERO based system which allows students to view and work with microscopy images using a web browser.


### PR DESCRIPTION
Bug - wrong menu-id flag was causing "Other OMERO Applications" submenu to close when Virtual Microscope was selected.

Test:
- open Other OMERO Applications submenu
- click on Figure item - submenu should stay open
- click on Virtual Microscope -  - submenu should stay open