### PR TITLE
Publishing Data - correct link to 5 rather than 5.1

### DIFF
--- a/publish.html
+++ b/publish.html
@@ -672,7 +672,7 @@ The Cell Image Library</a></p></li>
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<p>Full documentation on how to set up OMERO as a public repository and details of customisation options can be found in the <a href="https://www.openmicroscopy.org/site/support/omero5.1/sysadmins/index.html#optimizing-omero-as-a-data-repository" target="_blank" class="external-url">OMERO Repository documentation</a>.</p>
+<p>Full documentation on how to set up OMERO as a public repository and details of customisation options can be found in the <a href="https://www.openmicroscopy.org/site/support/omero5/sysadmins/index.html#optimizing-omero-as-a-data-repository" target="_blank" class="external-url">OMERO Repository documentation</a>.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->


### PR DESCRIPTION
Check that "OMERO Repository documentation" link at bottom of page goes to current - 5.2 - developer docs not the 5.1.4 version.

Review at: http://help.staging.openmicroscopy.org/publish.html#repository

PDF updated on downloads staging.