### PR TITLE
Training manual update

### DIFF
--- a/previous.html
+++ b/previous.html
@@ -59,21 +59,6 @@ version:
 <p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_4_4_8.zip">Version 4.4.8</a> (Zipped PDFs 165 MB)</p>
 
 <div class="line-block">
-  <div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
-<p><a href="http://downloads.openmicroscopy.org/help/pdfs/vib-training-manual.pdf" target="_blank">Training Manual</a> from visit to VIB KU Leuven in December 2012 (Version 4.4.4). (165 MB)</p>
-<p><a href="http://downloads.openmicroscopy.org/help/pdfs/vib-training-manual.pdf" target="_blank"><img src="images/thumbnails/vib_thumbnail.jpg" width="75" height="106" alt="VIB Thumbnail" class="float-left" /></a></p>
-
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-   
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
-<div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 

--- a/resources.html
+++ b/resources.html
@@ -14,6 +14,10 @@ version:
 
 <p>This generally helps the participants in the training session to get started and logged in with minimal confusion.</p>
 
+<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_1.zip">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
+
+<p>Sections or pages can be added or removed from the PDF using Preview on Mac OSX or Adode Acrobat.</p>
+
 <p>You can also select appropriate sections in the User Help website, and download the individual PDFs of the pages using the link at the top right of each page. These have been formatted for printing.</p>
 
 <p>Alternatively all the PDFs available for both OMERO versions can be downloaded as a zip archive using the links below.</p>

--- a/resources.html
+++ b/resources.html
@@ -14,7 +14,7 @@ version:
 
 <p>This generally helps the participants in the training session to get started and logged in with minimal confusion.</p>
 
-<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/pdfs/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual/training-manual-cover-sheet.doc">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
+<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/pdfs/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual/omero-training-manual-cover-sheet.doc">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
 
 <p>Sections or pages can be added or removed from the PDF using Preview on Mac OSX or Adode Acrobat.</p>
 

--- a/resources.html
+++ b/resources.html
@@ -14,7 +14,7 @@ version:
 
 <p>This generally helps the participants in the training session to get started and logged in with minimal confusion.</p>
 
-<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_1.zip">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
+<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/pdfs/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual/training-manual-cover-sheet.doc">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
 
 <p>Sections or pages can be added or removed from the PDF using Preview on Mac OSX or Adode Acrobat.</p>
 


### PR DESCRIPTION
Deleting VIB Training Course Manual link from the Previous versions page.

Checked with VIB - they don’t need the downloads anymore.

Add section to Training Materials page with links to new OMERO Training Manual PDF and Resources downloads.

On downloads staging:
- removed VIB Training Course Manual PDF and vib-login in resources]
- added omero-training-manual.pdf and training-manual folder in resources with coversheet etc. .docs in it