### PR TITLE
Update highlighter config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,6 @@ name: OMERO User Help Website
 gems:
   - jekyll-redirect-from
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 baseurl: /ome-help
 clsbaseurl: /ome-help/cls


### PR DESCRIPTION
See https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors - I got a build warning because our highlighter option is not supported by Jekyll version 3 which GitHub Pages has been upgraded to. 