### PR TITLE
Fix navigation in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -129,7 +129,7 @@ navigation:
                     <!-- Level 1 List -->
                     <ul class="level1" id="toggle-1">
 
-                        {% for level1 in page.navigation %}
+                        {% for level1 in layout.navigation %}
                         {% include navigation.html item=level1 %}
                         {% endfor %}
 


### PR DESCRIPTION
This fixes the display of navigation menu as described https://github.com/jekyll/jekyll/issues/4123
