### PR TITLE
Correcting URL typo in Previous

### DIFF
--- a/previous.html
+++ b/previous.html
@@ -12,7 +12,7 @@ version:
 
 <h3>Version 5</h3>
 
-<p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_1.zip">Version 5.2.2</a> (Zipped PDFs 135 MB)</p>
+<p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_2.zip">Version 5.2.2</a> (Zipped PDFs 135 MB)</p>
 
 <p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_1.zip">Version 5.2.1</a> (Zipped PDFs 134 MB)</p>
 


### PR DESCRIPTION
Link to 5.2.2 archive was incorrect.

Check URL.

No PDF changes.