### PR TITLE
Update User Help to Version 5.2.4

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -154,7 +154,7 @@ navigation:
                         <h1>{{ page.title }}</h1>
 
                         {% for yes in page.version %}
-                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.2.3</div>
+                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.2.4</div>
                         {% endfor %}
                         
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ version:
 
 <p>The <a href="resources.html">Training Course Material</a> page contains links to material for printing out and using in training sessions, ZIP archives of the PDFs for all the current versions, customised versions of some of the Guides and other resources such as  Omnigraffle&reg; and Word&reg; files.</p>
 
-<p>The current release version of OMERO.insight is 5.2.3. You can tell what version of OMERO you are using by looking at the login screen, or selecting <span class="bold">About OMERO.insight</span> from the Help menu in OMERO.insight.</p>
+<p>The current release version of OMERO.insight is 5.2.4. You can tell what version of OMERO you are using by looking at the login screen, or selecting <span class="bold">About OMERO.insight</span> from the Help menu in OMERO.insight.</p>
 
 <p><img src="images/indexVersion.jpg" alt="OMERO.insight Version" style="width: 80%;"/></p>
 

--- a/previous.html
+++ b/previous.html
@@ -12,6 +12,8 @@ version:
 
 <h3>Version 5</h3>
 
+<p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_3.zip">Version 5.2.3</a> (Zipped PDFs 135 MB)</p>
+
 <p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_2.zip">Version 5.2.2</a> (Zipped PDFs 135 MB)</p>
 
 <p>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_1.zip">Version 5.2.1</a> (Zipped PDFs 134 MB)</p>

--- a/resources.html
+++ b/resources.html
@@ -24,7 +24,7 @@ version:
 
 <ul>
 
-<li>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_3.zip">Version 5.2.3</a> (Zipped PDFs 135 MB)</li>
+<li>All User Guides for <a href="http://downloads.openmicroscopy.org/help/archives/OMERO_User_Guides_5_2_4.zip">Version 5.2.4</a> (Zipped PDFs 138 MB)</li>
 <br/>
 
 </ul>


### PR DESCRIPTION
Increment current version numbers in page header, resources.html and index.html.
Add 5.2.3 archive to previous.html

Note: PDFs and archives not updated on downloads staging yet - still to do.