### PR TITLE
Correcting navigation issue - submenu incorrect

### DIFF
--- a/group-owner.html
+++ b/group-owner.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Managing an OMERO Group
-menu-id: l1-other
+menu-id: l1-workflow2
 pdfs:
     - group-owner.pdf
 description: How to manage a group as a Group Owner on OMERO.


### PR DESCRIPTION
The Managing an OMERO Group page was not headed with the correct submenu - was closing Other More Workflow User Guides submenu when selected.

No change to any PDF.