### PR TITLE
Update current version number on SLS pages

### DIFF
--- a/_layouts/sls.html
+++ b/_layouts/sls.html
@@ -109,7 +109,7 @@ navigation:
                         <h1>{{ page.title }}</h1>
                          
                         {% for yes in page.version %}
-                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.2.3</div>
+                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.2.5</div>
                         {% endfor %}
                          
                     </div> <!-- End page-header -->


### PR DESCRIPTION
Updating the current version to 5.2.5 on the SLS specific pages: 
sls-index.html
sls-getting-started.html

No PDF updates needed.