### PR TITLE
Updating Training Manual PDF.

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -14,7 +14,7 @@ version:
 
 <p>This generally helps the participants in the training session to get started and logged in with minimal confusion.</p>
 
-<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/pdfs/omero-training-manual.pdf">OMERO Training Manual</a> (97.3 MB) document with a customisable cover page. The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual/omero-training-manual-cover-sheet.doc">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
+<p>We have edited and assembled the PDFs we routinely use for a training session into a single <a href="http://downloads.openmicroscopy.org/help/pdfs/omero-training-manual.pdf">OMERO Training Manual</a> (117 MB) document with a customisable cover page. Be warned that this document amounts to 125 pages all told! The appropriate date and a custom logo can be added by editing the  <a href="http://downloads.openmicroscopy.org/help/resources/omero-training-manual/omero-training-manual-cover-sheet.doc">training-manual-cover-sheet.doc</a> template and replacing the cover page in the PDF.</p>
 
 <p>Sections or pages can be added or removed from the PDF using Preview on Mac OSX or Adode Acrobat.</p>
 


### PR DESCRIPTION
The example training manual done in January 2016 had drifted to being out of date.

Refreshed with latest PDFs.
Add warning about size in text.
PDF in downloads staging.

PDF will need another update when ImageJ-Fiji section update completed - will just involve a push of downloads staging so will make sure updated PDF is there for when the ImageJ section gets made live.