### PR TITLE
Add Folders permissions note & tidy line lengths

### DIFF
--- a/measurement-tool.html
+++ b/measurement-tool.html
@@ -801,7 +801,7 @@ version:
 
 <li><p class="first">Enter the desired <span class="bold">X</span> or
     <span class="bold">Y</span> coordinate in the text box and click
-    <span class="bold">Apply</span,> or click on a point in the image to set
+    <span class="bold">Apply</span> or click on a point in the image to set
     the line plot position.</p>
 
 <div class="line-block">

--- a/measurement-tool.html
+++ b/measurement-tool.html
@@ -26,9 +26,11 @@ version:
 
 <h2><a class="anchor" id="introduction"></a>Introduction</h2>
 
-<p>The measurement tool in OMERO.insight is used to draw Regions of Interest (ROIs) and perform some basic analysis.</p>
+<p>The measurement tool in OMERO.insight is used to draw Regions of Interest
+    (ROIs) and perform some basic analysis.</p>
 
-<p>OMERO.web allows you to view existing ROIs, but not edit them or create new ones.</p>
+<p>OMERO.web allows you to view existing ROIs, but not edit them or create new
+    ones.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -38,7 +40,9 @@ version:
 
 <ol class="step">
 
-<li><p class="first">Open the image in the <span class="bold">Image Viewer</span> and click on the <span class="bold">Measuring Tool</span> icon to open the tool palette.</p>
+<li><p class="first">Open the image in the <span class="bold">Image
+    Viewer</span> and click on the <span class="bold">Measuring Tool</span>
+    icon to open the tool palette.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -52,9 +56,11 @@ version:
 
 </li>
 
-<li><p class="first">Use the <span class="bold">ROI selector</span> icon to select ROIs for analysis, resizing, reshaping or moving on image.</p>
+<li><p class="first">Use the <span class="bold">ROI selector</span> icon to
+    select ROIs for analysis, resizing, reshaping or moving on image.</p>
 
-<p>Select the appropriate tool to draw rectangular, ellipse, point, line or polygon ROIs.</p>
+<p>Select the appropriate tool to draw rectangular, ellipse, point, line or
+    polygon ROIs.</p>
 
 <p>Text ROIs can be added with the text tool.</p>
 
@@ -70,7 +76,9 @@ version:
 
 </li>
 
-<li><p class="first">Click on the <span class="bold">Rectangle</span> or <span class="bold">Ellipse</span> icons in the tool bar to draw a rectangular or elliptical ROI.</p>
+<li><p class="first">Click on the <span class="bold">Rectangle</span> or
+    <span class="bold">Ellipse</span> icons in the tool bar to draw a
+    rectangular or elliptical ROI.</p>
 
 <p>Use the corners or edges to resize the ROI.</p>
 
@@ -78,7 +86,8 @@ version:
 
 <p>Double-click on the ROI to add a label to the ROI.</li>
 
-<p>Use the <span class="bold">Show Comment</span> checkbox in the toolbar to toggle labels on and off.</p>
+<p>Use the <span class="bold">Show Comment</span> checkbox in the toolbar to
+    toggle labels on and off.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -98,7 +107,8 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">On elliptical ROIs click on and drag the green dot at the top to rotate the ellipse.</p>
+<li><p class="first">On elliptical ROIs click on and drag the green dot at
+    the top to rotate the ellipse.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -112,7 +122,8 @@ version:
 
 </li>
 
-<li><p class="first">Double-click on a line ROI to insert an additional point into the line.<p>
+<li><p class="first">Double-click on a line ROI to insert an additional point
+    into the line.<p>
 
 <img alt="../images/measurementToolLine.jpg" class="align-right" src="images/measurementToolLine.jpg" style="width: 80%;" />
 
@@ -128,11 +139,16 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first"><span class="bold">Ctrl-click</span> (Windows) or <span class="bold">Cmd-click</span> (Mac) changes the type of a point.<p>
+<li><p class="first"><span class="bold">Ctrl-click</span> (Windows) or
+    <span class="bold">Cmd-click</span> (Mac) changes the type of a point.<p>
 
-<p>The default type is an edge point, with collinear control point, unconstrained control point and quadratic curve point the other options.</p>
+<p>The default type is an edge point, with collinear control point,
+    unconstrained control point and quadratic curve point the other
+    options.</p>
 
-<p>Point types other than the default edge point, have Bezier controls that allow the line adjacent to the point to be curved as needed e.g. to pass through specific structures.</p>
+<p>Point types other than the default edge point, have Bezier controls that
+    allow the line adjacent to the point to be curved as needed e.g. to pass
+    through specific structures.</p>
 
 <img alt="../images/measurementToolPoint.jpg" class="align-right" src="images/measurementToolPoint.jpg" style="width: 94%;" />
 
@@ -146,23 +162,9 @@ version:
 
 </li>
 
-<li><p class="first">Click the <span class="bold">Polygon</span> icon, click on the image, and then click again to start drawing a polygon ROI on an image.<p>
-
-<p>Each subsequent click will draw another point.</p>
-
-<p>The type of any point on a polygon ROI can be changed by Ctrl-click or Cmd-click, and the line curved using the Bezier controls.</p>
-
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
-<img alt="../images/measurementToolPolygon.jpg" class="align-right" src="images/measurementToolPolygon.jpg" style="width: 80%;" />
-
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
-</li>
+<li><p class="first">Click the <span class="bold">Polygon</span> icon, click
+    on the image, and then click again to start drawing a polygon ROI on an
+    image.<p>
 
 <p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
 
@@ -170,7 +172,8 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Right-click on any ROI to use the contextual menu to perform the operations available.</p>
+<li><p class="first">Right-click on any ROI to use the contextual menu to
+    perform the operations available.</p>
 
 <p></p>
 
@@ -186,7 +189,8 @@ version:
 
 </li>
 
-<li><p class="first">Click on the <span class="bold">Save</span> icon to save ROIs.</p>
+<li><p class="first">Click on the <span class="bold">Save</span> icon to save
+    ROIs.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -200,7 +204,8 @@ version:
 
 </li>
 
-<li><p class="first">Click on the <span class="bold">Upload</span> icon to upload ROIs from an external file.</p>
+<li><p class="first">Click on the <span class="bold">Upload</span> icon to
+    upload ROIs from an external file.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -214,11 +219,14 @@ version:
 
 </li>
 
-<li><p class="first">Click the <span class="bold">Delete</span> button to delete all ROIs on an image.</p>
+<li><p class="first">Click the <span class="bold">Delete</span> button to
+    delete all ROIs on an image.</p>
 
-<p>Right-click on an individual ROI and select <span class="bold">Delete</span> to delete only a single ROI.</p>
+<p>Right-click on an individual ROI and select
+    <span class="bold">Delete</span> to delete only a single ROI.</p>
 
-<p>Select multiple ROIs, right-click and select **Delete** to delete those ROIs.</p>
+<p>Select multiple ROIs, right-click and select **Delete** to delete those
+    ROIs.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -247,17 +255,31 @@ version:
 
 <h2><a class="anchor" id="folders"></a>ROI Folders</h2>
 
-<p>ROI Folders provide a way of grouping ROIs on an image or across images for the purposes of organisation, analysis or visualisation. ROI Folders support hierarchies, so can contain both other folders and ROIs.</p>
+<p>ROI Folders provide a way of grouping ROIs on an image or across images for
+    the purposes of organisation, analysis or visualisation. ROI Folders
+    support hierarchies, so can contain both other folders and ROIs.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
+<div class="note">
+<p class="note-title">Note</p>
+<p class="note-text">There are still some permissions issues in OMERO.insight
+    meaning that at present, even in groups where the permissions should allow
+    this, you cannot add ROIs created by other people to Folders. If you are
+    comfortable using the Command Line Interface, you use that instead and
+    OMERO.insight will then display the Folder contents correctly.</p>
+</div><!-- End note -->
+
+
 <ol class="step">
 
-<li><p class="first">ROIs and folders are shown in the <span class="bold">Manager</span> tab of the Measurement Tool.</p>
+<li><p class="first">ROIs and folders are shown in the
+    <span class="bold">Manager</span> tab of the Measurement Tool.</p>
 
-<p>By default only folders containing ROIs on the image being viewed are shown.</p>
+<p>By default only folders containing ROIs on the image being viewed are
+    shown.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -273,7 +295,8 @@ version:
 
 <li><p class="first">Select one or more ROIs to add to a folder.</p>
 
-<p>Right-click on the selection and choose <span class="bold">Create Folder</span> from the menu.</p>
+<p>Right-click on the selection and choose <span class="bold">Create
+    Folder</span> from the menu.</p>
 
 <p>Type the name and any description into the text boxes.</p>
 
@@ -301,15 +324,20 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Click the <span class="bold">Add ROI Folders</span> button to add an existing folder to the Manager display.</p>
+<li><p class="first">Click the <span class="bold">Add ROI Folders</span>
+    button to add an existing folder to the Manager display.</p>
 
-<p>In the Add to ROI Folders dialog, select available folders in the left pane.</p>
+<p>In the Add to ROI Folders dialog, select available folders in the left
+    pane.</p>
 
-<p>Type in the text box above the Available pane to filter the ROI Folders shown.</p>
+<p>Type in the text box above the Available pane to filter the ROI Folders
+    shown.</p>
 
-<p>Click the <span class="bold">blue arrow</span> to add them to the Selected pane on the right.</p>
+<p>Click the <span class="bold">blue arrow</span> to add them to the Selected
+    pane on the right.</p>
 
-<p>Click <span class="bold">Save</span> to add the folders to the Manage display.</p>
+<p>Click <span class="bold">Save</span> to add the folders to the Manage
+    display.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -333,11 +361,19 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Use the drop-down menus below the pane, to refine the search parameters by selecting <span class="bold">Anywhere in the name</span> or <span class="bold">Start of the name</span>, <span class="bold">All</span>, <span class="bold">Owned by me</span>, or <span class="bold">Owned by others</span> from the menus.</p>
+<li><p class="first">Use the drop-down menus below the pane, to refine the
+    search parameters by selecting
+    <span class="bold">Anywhere in the name</span> or
+    <span class="bold">Start of the name</span>,
+    <span class="bold">All</span>, <span class="bold">Owned by me</span>, or
+    <span class="bold">Owned by others</span> from the menus.</p>
 
-<p>Create a new folder by typing the name in the text box at the bottom of the window, add any description, and clicking <span class="bold">Add</span>.</p>
+<p>Create a new folder by typing the name in the text box at the bottom of the
+    window, add any description, and clicking
+    <span class="bold">Add</span>.</p>
 
-<p>Click <span class="bold">Save</span> to add the folders to the Manage display.</p>
+<p>Click <span class="bold">Save</span> to add the folders to the Manage
+    display.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -351,7 +387,9 @@ version:
 
 </li>
 
-<li><p class="first">In the <span class="bold">Manager</span> tab of the Measurement Tool, use the <span class="bold">Filter ROI Folders</span> text box to filter the folders displayed.</p>
+<li><p class="first">In the <span class="bold">Manager</span> tab of the
+    Measurement Tool, use the <span class="bold">Filter ROI Folders</span>
+    text box to filter the folders displayed.</p>
 
 <p>Folders owned by other users have the shared flag on them.</p>
 
@@ -377,13 +415,19 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Right-click on a ROI and select <span class="bold">Add to Folder</span> to add the ROI to an existing or new folder.</p>
+<li><p class="first">Right-click on a ROI and select
+    <span class="bold">Add to Folder</span> to add the ROI to an existing or
+    new folder.</p>
 
-<p>On opening, the <span class="bold">Add to ROI Folders</span> dialog will only show folders currently displayed in the Management Tab.</p>
+<p>On opening, the <span class="bold">Add to ROI Folders</span> dialog will
+    only show folders currently displayed in the Management Tab.</p>
 
-<p>Use the <span class="bold">Filter ROI Folders</span> text box to filter by folder name.</p>
+<p>Use the <span class="bold">Filter ROI Folders</span> text box to filter by
+    folder name.</p>
 
-<p>Click on the <span class="bold">Source</span> drop-down and select the <span class="bold">All Folders</span> option to display all the folders in the system.</p>
+<p>Click on the <span class="bold">Source</span> drop-down and select the
+    <span class="bold">All Folders</span> option to display all the folders in
+    the system.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -397,19 +441,11 @@ version:
 
 </li>
 
-<li><p class="first">Drag and drop a ROI onto a folder to add it, or out of a folder to remove it.</p>
+<li><p class="first">Drag and drop a ROI onto a folder to add it, or out of a
+    folder to remove it.</p>
 
-<p>Similarly folders can be dragged and dropped in and out of other folders.</p>
-
-<p>When dragging a ROI out of a folder to orphan it, it needs to be dragged clear of the last ROI at the bottom of the list.</p>
-
-<div class="line-block">
-<div class="line"><br /></div> <!-- end #line -->
-</div> <!-- end #line-block -->
-
-</li>
-
-<li><p class="first">Right-click on a ROI within a folder and select <span class="bold">Remove from Folder</span> to orphan a ROI.</p>
+<li><p class="first">Right-click on a ROI within a folder and select
+    <span class="bold">Remove from Folder</span> to orphan a ROI.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -429,9 +465,12 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Right-click on a folder within another folder and choose <span class="bold">Move Folder</span> from the menu to move a folder and its contents to another folder or to orphan it.</p>
+<li><p class="first">Right-click on a folder within another folder and choose
+    <span class="bold">Move Folder</span> from the menu to move a folder and
+    its contents to another folder or to orphan it.</p>
 
-<p>Select a folder or <span class="bold">None</span> in the Destination Folder window.</p>
+<p>Select a folder or <span class="bold">None</span> in the Destination Folder
+    window.</p>
 
 <p>Click <span class="bold">OK</span>.</p>
 
@@ -447,9 +486,11 @@ version:
 
 </li>
 
-<li><p class="first">Deselect or select the <span class="bold">Show</span> checkbox to hide or show folders or ROIs.</p>
+<li><p class="first">Deselect or select the <span class="bold">Show</span>
+    checkbox to hide or show folders or ROIs.</p>
 
-<p>A change in the state of the Show checkbox for a folder is also applied to the contents of the folder.</p>
+<p>A change in the state of the Show checkbox for a folder is also applied to
+    the contents of the folder.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -467,7 +508,8 @@ version:
 
 <div class="note">
 <p class="note-title">Note</p>
-<p class="note-text">All these operations can be performed on multi-selected objects.</p>
+<p class="note-text">All these operations can be performed on multi-selected
+    objects.</p>
 </div><!-- End note -->
 
 <p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
@@ -484,9 +526,11 @@ version:
 
 <ol class="step">
 
-<li><p class="first">Any ROI drawn will be on the currently viewed Z section and time point.</p>
+<li><p class="first">Any ROI drawn will be on the currently viewed Z section
+    and time point.</p>
 
-<p>Click on the <span class="bold">ROI Assistant</span> icon to propagate an ROI across Z sections or time points.</p>
+<p>Click on the <span class="bold">ROI Assistant</span> icon to propagate an
+    ROI across Z sections or time points.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -500,13 +544,15 @@ version:
 
 </li>
 
-<li><p class="first">In the <span class="bold">ROI Assistant</span> window, click on the ROI and drag it.</p>
+<li><p class="first">In the <span class="bold">ROI Assistant</span> window,
+    click on the ROI and drag it.</p>
 
 <p>Up or down propagates through the Z sections.</p>
 
 <p>Drag left or right to propagate through the time points (T).</p>
 
-<p>Dragging diagonally will propagate the ROI through both Z sections and time points.</p>
+<p>Dragging diagonally will propagate the ROI through both Z sections and time
+    points.</p>
 
 <p>Click <span class="bold">Close</span> to return to the ROI palette.</p>
 
@@ -522,7 +568,9 @@ version:
 
 </li>
 
-<li><p class="first">Click the <span class="bold">Remove ROI</span> radio button and click and drag on ROIs to remove them from Z sections or time points.</p>
+<li><p class="first">Click the <span class="bold">Remove ROI</span> radio
+    button and click and drag on ROIs to remove them from Z sections or time
+    points.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -554,7 +602,8 @@ version:
 <ol class="step">
 
 
-<li><p class="first">Details of <span class="bold">ROIs</span> are viewed in the **Manager** tab of the tool palette.</p>
+<li><p class="first">Details of <span class="bold">ROIs</span> are viewed in
+    the **Manager** tab of the tool palette.</p>
 
 <p>The columns show:</p>
 
@@ -581,7 +630,10 @@ version:
 
 </li>
 
-<li><p class="first">Select an ROI and click on the <span class="bold">Inspector</span> tab to view and edit the text label, dimensions, fill and line color, and toggle the visibility of the text and measurements on and off.</p>
+<li><p class="first">Select an ROI and click on the
+    <span class="bold">Inspector</span> tab to view and edit the text label,
+    dimensions, fill and line color, and toggle the visibility of the text and
+    measurements on and off.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -601,11 +653,15 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Click on the <span class="bold">Graph Pane</span> tab to show a plot of the channel intensity values for an ROI.</p>
+<li><p class="first">Click on the <span class="bold">Graph Pane</span> tab to
+    show a plot of the channel intensity values for an ROI.</p>
 
-<p>A line ROI has a profile of intensity values along the line and a histogram of intensity vs. frequency (other types of ROI show only the histogram).</p>
+<p>A line ROI has a profile of intensity values along the line and a histogram
+    of intensity vs. frequency (other types of ROI show only the
+    histogram).</p>
 
-<p>If an ROI is propagated across Z sections or time points, the sliders to the left of the histogram allow stepping through the sequences.</p>
+<p>If an ROI is propagated across Z sections or time points, the sliders to
+    the left of the histogram allow stepping through the sequences.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -619,7 +675,8 @@ version:
 
 </li>
 
-<li><p class="first">Click on the <span class="bold">Intensity View</span> tab to see tables of intensity values for the ROI.</p>
+<li><p class="first">Click on the <span class="bold">Intensity View</span> tab
+    to see tables of intensity values for the ROI.</p>
 
 <p>>These values can be exported in Excel format for further analysis.</p>
 
@@ -633,9 +690,12 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Click on the <span class="bold">Intensity Results View</span> tab to see tables of intensity values for the ROI.</p>
+<li><p class="first">Click on the
+    <span class="bold">Intensity Results View</span> tab to see tables of
+    intensity values for the ROI.</p>
 
-<p>Click <span class="bold">Add Selected</span> to show results for the selected ROI.</p>
+<p>Click <span class="bold">Add Selected</span> to show results for the
+    selected ROI.</p>
 
 <p>These values can be exported in Excel format for further analysis.</p>
 
@@ -659,13 +719,16 @@ version:
 
 <h2><a class="anchor" id="web"></a>Viewing ROIs in OMERO.web</h2>
 
-<p>ROIs cannot be drawn in OMERO.web, but can be viewed, along with basic line plot of channel intensity values.</p>
+<p>ROIs cannot be drawn in OMERO.web, but can be viewed, along with basic line
+    plot of channel intensity values.</p>
 
 <ol class="step">
 
-<li><p class="first">Open the image in the <span class="bold">Full Viewer</span>.</p>
+<li><p class="first">Open the image in the
+    <span class="bold">Full Viewer</span>.</p>
 
-<p>Click the <span class="bold">Show ROIs</span> link at the bottom of the toolbar.</p>
+<p>Click the <span class="bold">Show ROIs</span> link at the bottom of the
+    toolbar.</p>
 
 <p>The ROIs palette opens in the top left corner.</p>
 
@@ -683,7 +746,8 @@ version:
 
 </li>
 
-<li><p class="first">Click on the <span class="bold">Expansion Arrow</span> on propagated ROIs to show the shapes on Z sections or time points.</p>
+<li><p class="first">Click on the <span class="bold">Expansion Arrow</span> on
+    propagated ROIs to show the shapes on Z sections or time points.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -703,7 +767,8 @@ version:
 <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
-<li><p class="first">Click the <span class="bold">Line Plot</span> check box to show a line plot on the image.</p>
+<li><p class="first">Click the <span class="bold">Line Plot</span> check box
+    to show a line plot on the image.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->
@@ -717,7 +782,8 @@ version:
 
 </li>
 
-<li><p class="first">Select orientation from the <span class="bold">Axis</span> drop-down.</p>
+<li><p class="first">Select orientation from the
+    <span class="bold">Axis</span> drop-down.</p>
 
 <p>Click <span class="bold">Apply</span>.</p>
 
@@ -733,7 +799,10 @@ version:
 
 </li>
 
-<li><p class="first">Enter the desired <span class="bold">X</span> or <span class="bold">Y</span> coordinate in the text box and click <span class="bold">Apply</span,> or click on a point in the image to set the line plot position.</p>
+<li><p class="first">Enter the desired <span class="bold">X</span> or
+    <span class="bold">Y</span> coordinate in the text box and click
+    <span class="bold">Apply</span,> or click on a point in the image to set
+    the line plot position.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->


### PR DESCRIPTION
Following the addition to https://github.com/openmicroscopy/ome-documentation/pull/1658 this PR adds a note about the permissions issue with Folders in insight to the help page.

I've also sorted the line lengths so this page is easier to review in future. New content starts at line 266.

Staged at http://help.staging.openmicroscopy.org/measurement-tool.html#folders