### PR TITLE
Update open with link on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,9 @@ version:
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="figure.html" target="blank">Open With...</a> - provides a new option for opening selected images using OMERO.figure or other custom plugins.</p>
+<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="web-client.html" target="blank">Open With...</a> -
+    provides a new option for opening selected images using OMERO.figure or
+    other custom OMERO.web plugins.</p>
 
 
 <div class="line-block">


### PR DESCRIPTION
When Will & I added the 'open with' section to the web client guide because the updated figure guide isn't going live yet, I forgot to update the link in the what's new section of the index page.

Staged at http://help.staging.openmicroscopy.org