### PR TITLE
Add demo version flag & change download link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,10 +161,10 @@ navigation:
 
                         <div class="version-flag">
                         {% for yes in page.version %}
-                        <span>Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.1</span>
+                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.1
                         {% endfor %}
                         {% for yes in page.demo-version %}
-                        <span>Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.2.8</span>
+                        Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.2.8
                         {% endfor %}
                         </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -159,10 +159,14 @@ navigation:
 
                         <h1>{{ page.title }}</h1>
 
+                        <div class="version-flag">
                         {% for yes in page.version %}
-                        <div class="version-flag">Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.1</div>
+                        <span>Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.1</span>
                         {% endfor %}
-                        
+                        {% for yes in page.demo-version %}
+                        <span>Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.2.8</span>
+                        {% endfor %}
+                        </div>
 
                     </div> <!-- End page-header -->
                     <div id="page-body">

--- a/demo-server.html
+++ b/demo-server.html
@@ -3,7 +3,7 @@ layout: default
 title: OMERO Demo Server
 menu-id: l1-quickstart
 description: Details on how to request a free account on our demo server to enable you to explore the OMERO platform using examples of your own data.
-version:
+demo-version:
     - yes
 ---
 <div class="page-navigation">
@@ -238,7 +238,7 @@ version:
                 class="bold">OMERO.insight</span> client for your platform by
                 clicking on the appropriate link on the <a class="reference
                 external"
-                href="http://downloads.openmicroscopy.org/latest/omero5/"
+                href="http://downloads.openmicroscopy.org/latest/omero5.2/"
                 target="_blank">downloads page</a>.
             </p>
 


### PR DESCRIPTION
See https://trello.com/c/PCx9cCDa/561-change-demo-server-downloads-link

The current set-up assumes Demo is being upgraded pretty much as soon as the release goes out, which is not happening at the moment and causes issues when it means the download link is pointing at an incompatible insight client.

This introduces a separate version flag for the demo server so we can update it once the server is upgraded rather than when we release and also changes the download link to a minor version specific one.

Staged at http://help.staging.openmicroscopy.org/demo-server.html