### PR TITLE
Update to 5.3.2 for release

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,7 +161,7 @@ navigation:
 
                         <div class="version-flag">
                         {% for yes in page.version %}
-                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.1
+                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.2
                         {% endfor %}
                         {% for yes in page.demo-version %}
                         Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.2.8

--- a/index.html
+++ b/index.html
@@ -5,21 +5,55 @@ description: The Home page for the User Help documentation for OMERO.insight, OM
 version:
     - yes
 ---
-<p>These pages contain the User Help for applications which can connect to an OMERO server or use OMERO plugins.</p>
+<p>
+    These pages contain the User Help for applications which can connect to an
+    OMERO server or use OMERO plugins.
+</p>
 
-<p>The User Guides for the current versions are listed in the main menu, for all OMERO applications, including OMERO.insight, OMERO.web, OMERO.figure and OMERO in ImageJ and Fiji.</p>
+<p>
+    The User Guides for the current versions are listed in the main menu, for
+    all OMERO applications, including OMERO.insight, OMERO.web, OMERO.figure
+    and OMERO in ImageJ and Fiji.
+</p>
 
-<p><a href="http://downloads.openmicroscopy.org/help/archives/">Guides for Previous Versions</a> are available from the downloads archive.</p>
+<p>
+    <a href="http://downloads.openmicroscopy.org/help/archives/">Guides for
+    Previous Versions</a> are available from the downloads archive.
+</p>
 
-<p>The <a href="resources.html">Training Course Material</a> page contains links to material for adapting for use in training sessions including Omnigraffle&reg; and Word&reg; files.</p>
+<p>
+    The <a href="resources.html">Training Course Material</a> page contains
+    links to material for adapting for use in training sessions including
+    Omnigraffle&reg; and Word&reg; files.
+</p>
 
-<p>The current release version of OMERO.insight is 5.3.1. You can tell what version of OMERO you are using by looking at the login screen, or selecting <span class="bold">About OMERO.insight</span> from the Help menu in OMERO.insight.</p>
+<p>
+    The current release version of OMERO.insight is 5.3.2. You can tell what
+    version of OMERO you are using by looking at the login screen, or
+    selecting <span class="bold">About OMERO.insight</span> from the Help menu
+    in OMERO.insight.
+</p>
 
-<p><img src="images/indexVersion.jpg" alt="OMERO.insight Version" style="width: 80%;"/></p>
+<p>
+    <img src="images/indexVersion.jpg" alt="OMERO.insight Version"
+    style="width: 80%;"/>
+</p>
 
-<p>All the Version 5 material on the User Help website applies to version 5.2 and 5.3, with the exception of the new features mentioned below, but note that version 5.2 is now in maintenance mode and will not be updated unless a major security issue is found.</p>
+<p>
+    All the Version 5 material on the User Help website applies to version 5.2
+    and 5.3, with the exception of the new features mentioned below, but note
+    that version 5.2 is now in maintenance mode and will not be updated unless
+    a major security issue is found.
+</p>
 
-<p>All material is covered by the <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 Unported License</a> - you are free to share or adapt content as long as you credit the Open Microscopy Environment. The exception to this is the screenshots and videos which can only be used for non-commercial purposes.</p>
+<p>
+    All material is covered by the <a 
+    href="http://creativecommons.org/licenses/by/4.0/">Creative Commons
+    Attribution 4.0 Unported License</a> - you are free to share or adapt
+    content as long as you credit the Open Microscopy Environment. The
+    exception to this is the screenshots and videos which can only be used for
+    non-commercial purposes.
+</p>
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
@@ -32,40 +66,68 @@ version:
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="measurement-tool.html#folders" target="blank">ROI Folders</a> - provide a way of grouping ROIs on an image or across images for the purposes of organization, analysis or visualization.</p>
+<p>
+    <img src="images/indexNew530.png" alt="New flag image" 
+    class="flag-left"/><a href="measurement-tool.html#folders" 
+    target="blank">ROI Folders</a> - provide a way of grouping ROIs on an
+    image or across images for the purposes of organization, analysis or
+    visualization.
+</p>
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="getting-started-5.html#viewing-data" target="blank">Lookup Table Support</a> - channel color selection now includes the option to select from commonly used lookup tables (LUTs) via the color picker.</p>
+<p>
+    <img src="images/indexNew530.png" alt="New flag image" 
+    class="flag-left"/><a href="getting-started-5.html#viewing-data" 
+    target="blank">Lookup Table Support</a> - channel color selection now
+    includes the option to select from commonly used lookup tables (LUTs) via
+    the color picker.
+</p>
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="viewing-data.html#rendering" target="blank">Histograms</a> - pixel intensity for channels can now be displayed as a histogram in the rendering settings.</p>
+<p>
+    <img src="images/indexNew530.png" alt="New flag image" 
+    class="flag-left"/><a href="viewing-data.html#rendering" 
+    target="blank">Histograms</a> - pixel intensity for channels can now be
+    displayed as a histogram in the rendering settings.
+</p>
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="web-client.html" target="blank">Open With...</a> -
-    provides a new option for opening selected images using OMERO.figure or
-    other custom OMERO.web plugins.</p>
+<p>
+    <img src="images/indexNew530.png" alt="New flag image" 
+    class="flag-left"/><a href="web-client.html" target="blank">Open
+    With...</a> - provides a new option for opening selected images using
+    OMERO.figure or other custom OMERO.web plugins.
+</p>
 
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p><img src="images/indexNew530.png" alt="New flag image" class="flag-left"/><a href="viewing-data.html#screen" target="blank">Screen Plate Grid View</a> - the fields in a Well are displayed as a grid in the center pane when viewing screening data.
+<p>
+    <img src="images/indexNew530.png" alt="New flag image" 
+    class="flag-left"/><a href="viewing-data.html#screen" 
+    target="blank">Screen Plate Grid View</a> - the fields in a Well are
+    displayed as a grid in the center pane when viewing screening data.
+</p>
 
 <div class="line-block">
   <div class="line"><br /></div> <!-- end #line -->
 </div><!-- end #line-block -->
 
-<p class="top_link"><a href="#top"><img src="images/back_to_top.png" alt="Image for link to top of page" style="float: right;"/></a></p>
+<p class="top_link">
+    <a href="#top"><img src="images/back_to_top.png" alt="Image for link to 
+    top of page" style="float: right;"/></a>
+</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->


### PR DESCRIPTION
Updates http://help.staging.openmicroscopy.org ready for the OMERO 5.3.2 release next week.

Main index page should now show 5.3.2 as the current release and all the versioned guides should display 5.3.2 in the top left EXCEPT the demo server page which is intentionally separately labelled as Demo is not upgraded to 5.3.x yet.