### PR TITLE
Update demo version to 5.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "jekyll"
 gem("jekyll", '< 3.5.0')
 gem "html-proofer"
 gem "jekyll-redirect-from"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "jekyll"
+gem("jekyll", '< 3.5.0')
 gem "html-proofer"
 gem "jekyll-redirect-from"

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: OMERO User Help Website
-gems:
+plugins:
   - jekyll-redirect-from
 markdown: redcarpet
 highlighter: rouge

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,5 +1,5 @@
 name: OMERO User Help Website
-gems:
+plugins:
   - jekyll-redirect-from
 markdown: redcarpet
 highlighter: rouge

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -164,7 +164,7 @@ navigation:
                         Current OMERO Version:&nbsp;&nbsp;&nbsp;5.3.2
                         {% endfor %}
                         {% for yes in page.demo-version %}
-                        Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.2.8
+                        Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.3.2
                         {% endfor %}
                         </div>
 

--- a/demo-server.html
+++ b/demo-server.html
@@ -238,7 +238,7 @@ demo-version:
                 class="bold">OMERO.insight</span> client for your platform by
                 clicking on the appropriate link on the <a class="reference
                 external"
-                href="http://downloads.openmicroscopy.org/latest/omero5.2/"
+                href="http://downloads.openmicroscopy.org/latest/omero5.3/"
                 target="_blank">downloads page</a>.
             </p>
 


### PR DESCRIPTION
See https://trello.com/c/35Xpehad/4-demo-530-re-deploymentd

This PR updates http://help.openmicroscopy.org/demo-server.html to indicate that the demo server is now up-to-date and to link to the new client downloads - I've left the downloads link version specific erring on the side of assuming a delay in upgrading in future.

Staged at http://help.staging.openmicroscopy.org/demo-server.html