### PR TITLE
Add lightadmin anchor stub to fix docs build

### DIFF
--- a/facility-manager.html
+++ b/facility-manager.html
@@ -25,6 +25,10 @@ version:
     </p>
 </div><!-- End Page Navigation -->
 
+<!-- Temporary stub to add anchor link for the docs build. To be removed when prepping for 5.4.0 release-->
+<div class="anchor" id="lightadmin"></div>
+<!-- End stub -->
+
 <div class="line-block">
     <div class="line"><br /></div>
 </div>


### PR DESCRIPTION
As discussed on https://github.com/openmicroscopy/ome-documentation/pull/1734#issuecomment-324004910 this adds a temporary 'lightadmin' anchor to get rid of the docs build error until we are ready to release 5.4.0