### PR TITLE
Update current version to 5.4.1

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,7 +161,7 @@ navigation:
 
                         <div class="version-flag">
                         {% for yes in page.version %}
-                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.4.0
+                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.4.1
                         {% endfor %}
                         {% for yes in page.demo-version %}
                         Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.4.0

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ version:
 </p>
 
 <p>
-    The current release version of OMERO.insight is 5.4.0. You can tell what
+    The current release version of OMERO.insight is 5.4.1. You can tell what
     version of OMERO you are using by looking at the login screen, or
     selecting <span class="bold">About OMERO.insight</span> from the Help menu
     in OMERO.insight.


### PR DESCRIPTION
This updates the current OMERO version to 5.4.1.

I'll open a separate PR for Nightshade & Demo as they likely won't be upgraded until next week or later.