### PR TITLE
Move info anchor to screenshot in Figure

### DIFF
--- a/figure.html
+++ b/figure.html
@@ -15,7 +15,7 @@ description: Use OMERO.figure to create, save and edit figures using data from t
         <a href="#labels">Adding labels, time series and extra rows</a><br />
         <a href="#rois">Adding and editing ROIs</a><br />
         <a href="#files">Adding different file types and legends</a><br />
-        <a href="#info">Configuring, saving and exporting your figure</a><br />
+        <a href="#saving">Configuring, saving and exporting your figure</a><br />
     </p>
 </div><!-- End Page Navigation -->
 
@@ -852,7 +852,7 @@ description: Use OMERO.figure to create, save and edit figures using data from t
 
 </li>
 
-<h2><a class="anchor" id="info"></a>Configuring, saving and exporting your
+<h2><a class="anchor" id="saving"></a>Configuring, saving and exporting your
     figure
 </h2>
 
@@ -897,6 +897,7 @@ description: Use OMERO.figure to create, save and edit figures using data from t
     <div class="line"><br /></div> <!-- end #line -->
 </div> <!-- end #line-block -->
 
+<a class="anchor" id="info"></a>
 <img alt="../images/figureDPI.jpg" class="align-center" src="images/figureDPI.jpg" style="width: 100%;" />
 
 <div class="line-block">


### PR DESCRIPTION
Requested by @pwalczysko so that the link in https://github.com/openmicroscopy/ome-documentation/pull/1815 points to the screenshot rather than the top of the section.