### PR TITLE
OMERO 5.4.5 release update

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -161,7 +161,7 @@ navigation:
 
                         <div class="version-flag">
                         {% for yes in page.version %}
-                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.4.4
+                        Current OMERO Version:&nbsp;&nbsp;&nbsp;5.4.5
                         {% endfor %}
                         {% for yes in page.demo-version %}
                         Current OMERO Demo Version:&nbsp;&nbsp;&nbsp;5.4.4

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ version:
 </p>
 
 <p>
-    The current release version of OMERO.insight is 5.4.4. You can tell what
+    The current release version of OMERO.insight is 5.4.5. You can tell what
     version of OMERO you are using by looking at the login screen, or
     selecting <span class="bold">About OMERO.insight</span> from the Help menu
     in OMERO.insight.


### PR DESCRIPTION
Updates the main OMERO version number to 5.4.5 as per https://trello.com/c/rT8eV3D1/6-update-help-site

I'll open another PR to update Nightshade & Demo separately.