### PR TITLE
Fixing the insecure message from Chrome

### DIFF
--- a/css/display.css
+++ b/css/display.css
@@ -4,8 +4,8 @@ Stylesheet for the OMERO User Guides Website
 All material is covered by the Creative Commons Attribution 3.0 Unported License - you are free to share or adapt content as long as you credit the Open Microscopy Environment. The exception to this is the screenshots and videos which can only be used for non-commercial purposes.
 */
 
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
-@import url(http://fonts.googleapis.com/css?family=Roboto:300,400,500,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans);
+@import url(https://fonts.googleapis.com/css?family=Roboto:300,400,500,700);
 
 * {
 	margins: 0;


### PR DESCRIPTION
The reference to an `http` URL in the CSS source causes a warning from Chrome.
![screen shot 2018-08-08 at 13 52 15](https://user-images.githubusercontent.com/2727871/43839543-4ab6d844-9b16-11e8-907b-4212ba7aba99.png)

Now that GH supports https on github pages by default, fixing this will fix the error.

Loading dev tools you see that the two CSS requests are what is sent across the wire after "load insecure content" is chosen.

It's possible to check that these are valid URLs by executing:

```
2018-08-08 14:19 LS27172:ome-help kenny$ curl -svL https://fonts.googleapis.com/css?family=Open+Sans 2>&1 | grep HTTP
> GET /css?family=Open+Sans HTTP/1.1
< HTTP/1.1 200 OK
2018-08-08 14:19 LS27172:ome-help kenny$ curl -svL https://fonts.googleapis.com/css?family=Roboto:300,400,500,700 2>&1 | grep HTTP
> GET /css?family=Roboto:300,400,500,700 HTTP/1.1
< HTTP/1.1 200 OK
```