### PR TITLE
Flimfit url fixed & file format list reference removed

### DIFF
--- a/flimfit.html
+++ b/flimfit.html
@@ -55,7 +55,7 @@ description: FLIMfit is a software tool from, Imperial College London, that is d
 
 <p>A list of file formats supported by FLIMfit can be found on the OME website <a href="http://flimfit.org/" target="_blank" class="external-url">FLIMfit page</a>.</p>
 
-<p>Further details about FLIMfit can be found on the <a href="http://imperial-photonics.github.io/FLIMfit/" target="_blank" class="external-url">FLIMfit website</a>.</p>
+<p>Further details about FLIMfit can be found on the <a href="https://flimfit.org/" target="_blank" class="external-url">FLIMfit website</a>.</p>
 
 <div class="line-block">
 <div class="line"><br /></div> <!-- end #line -->

--- a/flimfit.html
+++ b/flimfit.html
@@ -53,8 +53,6 @@ description: FLIMfit is a software tool from, Imperial College London, that is d
 
 <p>Details on how to import data to OMERO are described in the <a href="http://help.openmicroscopy.org/importing-data-5.html" target="_blank" >Importing Data</a> section.</p>
 
-<p>A list of file formats supported by FLIMfit can be found on the OME website <a href="http://flimfit.org/" target="_blank" class="external-url">FLIMfit page</a>.</p>
-
 <p>Further details about FLIMfit can be found on the <a href="https://flimfit.org/" target="_blank" class="external-url">FLIMfit website</a>.</p>
 
 <div class="line-block">


### PR DESCRIPTION
Moving http://imperial-photonics.github.io/FLIMfit/ (404) to the new https://flimfit.org/

Removing "list of file formats" which must have existed on plone, but doesn't exist afak on the new flimfit.org.