### PR TITLE
Bump OMERO version to 5.4.10

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ markdown: redcarpet
 highlighter: rouge
 
 omero:
-  version: 5.4.9
+  version: 5.4.10
 
 baseurl: /ome-help
 clsbaseurl: /ome-help/cls


### PR DESCRIPTION
Especially for OMERO.insight clients, this release contains critical update
to work with the latest Java release